### PR TITLE
Fix bad examples and small configurator bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ leogout_seo:
 
 ## Setting values dynamically
 
-You can get the `leogout_seo.generator.[basic|twitter|og]` as a service to set or override any values.
+You can get the `'[basic|twitter|og]` as a service to set or override any values.
 Each value of the configuration can be overrided using a setter of the following form:
-`$this->get('leogout_seo.generator.` **[basic|twitter|og]** `')->set` **[config field name]** `(` **[value]** `)`
+`$this->get('leogout_seo.provider.generator')->get('` **[basic|twitter|og]** `')->set` **[config field name]** `(` **[value]** `)`
 
 For example, if you want to change `title` and `robots` from `basic`, you can do this:
 ```php
@@ -123,7 +123,7 @@ class DefaultController extends Controller
 You can configure your own model classes to let the seo generators do all the work thanks to the **fromResource()** method.
 Multiple interfaces are available to help the method guess which setters to call to fill the tags.
 
-This is an exemple for the `leogout_seo.generator.basic` generator:
+This is an exemple for the `basic` generator:
 **In your resource:**
 ```php
 use Leogout\Bundle\SeoBundle\Seo\Basic\BasicSeoInterface;
@@ -191,9 +191,9 @@ class MyController extends Controller
 ```
 
 There are **three** main interfaces, one for each generator:
-* `BasicSeoInterface` for `leogout_seo.generator.basic`
-* `OgSeoInterface` for `leogout_seo.generator.og`
-* `TwitterSeoInterface` for `leogout_seo.generator.twitter`
+* `BasicSeoInterface` for `basic`
+* `OgSeoInterface` for `og`
+* `TwitterSeoInterface` for `twitter`
 
 These interfaces extends _simpler interfaces_ which you can inplement instead or additionnally.
 For example, if you only have a meta description on your resource, you can implement `DescriptionSeoInterface` only to provide a description alone.
@@ -250,7 +250,7 @@ class MyController extends Controller
 {
     public function indexAction(Request $request)
     {
-        $this->get('app.seo_generator.my_tags')->setMyTag('cool');
+        $this->get('leogout_seo.provider.generator')->get('my_tags')->setMyTag('cool');
         
         return $this->render('MyController:Default:index.html.twig');
     }

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class DefaultController extends Controller
 {
     public function indexAction()
     {
-        $this->get('leogout_seo.generator.basic')
+        $this->get('leogout_seo.provider.generator')->get('basic')
             ->setTitle('Title set in controller')
             ->setRobots(true, false); // they can be chained
         
@@ -167,7 +167,7 @@ class MyController extends Controller
             ->addKeyword('ho')
             ->addKeyword('let's go!');
         
-        $this->get('leogout_seo.generator.basic')->fromResource($myResource);
+        $this->get('leogout_seo.provider.generator')->get('basic')->fromResource($myResource);
         
         return $this->render('MyController:Default:index.html.twig');
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="leogout_seo.provider.generator" class="Leogout\Bundle\SeoBundle\Provider\SeoGeneratorProvider" public="false">
+        <service id="leogout_seo.provider.generator" class="Leogout\Bundle\SeoBundle\Provider\SeoGeneratorProvider" public="true">
             <argument type="collection"/>
         </service>
         <service id="leogout_seo.tag_factory" class="Leogout\Bundle\SeoBundle\Factory\TagFactory"/>

--- a/Seo/Og/OgSeoConfigurator.php
+++ b/Seo/Og/OgSeoConfigurator.php
@@ -34,7 +34,7 @@ class OgSeoConfigurator extends AbstractSeoConfigurator
             $generator->setType($type);
         }
         if (null !== $url = $this->getConfig('url')) {
-            $generator->setImage($url);
+            $generator->setUrl($url);
         }
     }
 }


### PR DESCRIPTION
These examples did not seem to work for me. I spent a lot of time trying all your examples but none worked. The generators are loaded and setted, but those are not the objects used in the end.

Although there is a service called `leogout_seo.generator.twitter` (for example), the instance is not the same as what's being used by SeoGeneratorProvider. The end result is that the tags don't show up, because we are setting them on the wrong object. The new approach I used does work.

I think this has something to do with how SeoGeneratorPass loads the generators, but I am new to Symfony and I'm not sure what a better approach would look like.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leogout/seobundle/5)
<!-- Reviewable:end -->
