### PR TITLE
reusable references to providers

### DIFF
--- a/DependencyInjection/Compiler/SeoGeneratorPass.php
+++ b/DependencyInjection/Compiler/SeoGeneratorPass.php
@@ -4,6 +4,7 @@ namespace Leogout\Bundle\SeoBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Description of SeoGeneratorPass.
@@ -19,7 +20,7 @@ class SeoGeneratorPass implements CompilerPassInterface
     {
         $definition = $container->getDefinition('leogout_seo.provider.generator');
         $taggedServices = $container->findTaggedServiceIds('leogout_seo.generator');
-        $seoGenerators = [];
+
         foreach ($taggedServices as $id => $tags) {
             $generatorDefinition = $container->getDefinition($id);
             if (!$generatorDefinition->isPublic()) {
@@ -32,9 +33,9 @@ class SeoGeneratorPass implements CompilerPassInterface
                 if (empty($attributes['alias'])) {
                     throw new \InvalidArgumentException(sprintf('Tag "leogout_seo.generator" requires an "alias" field in "%s" definition.', $id));
                 }
-                $seoGenerators[$attributes['alias']] = $container->findDefinition($id);
+
+                $definition->addMethodCall('set', [$attributes['alias'], new Reference($id)]);
             }
         }
-        $definition->replaceArgument(0, $seoGenerators);
     }
 }

--- a/Provider/SeoGeneratorProvider.php
+++ b/Provider/SeoGeneratorProvider.php
@@ -17,13 +17,16 @@ class SeoGeneratorProvider
     protected $generators = [];
 
     /**
-     * SeoGeneratorProvider constructor.
+     * @param string $alias
+     * @param AbstractSeoGenerator $generator
      *
-     * @param array $generators
+     * @return self
      */
-    public function __construct(array $generators)
+    public function set(string $alias, AbstractSeoGenerator $generator)
     {
-        $this->generators = $generators;
+        $this->generators[$alias] = $generator;
+
+        return $this;
     }
 
     /**

--- a/Resources/config/seo/basic.xml
+++ b/Resources/config/seo/basic.xml
@@ -14,5 +14,8 @@
             <configurator service="leogout_seo.configurator.basic" method="configure" />
             <tag name="leogout_seo.generator" alias="basic"/>
         </service>
+
+        <!-- for autowiring -->
+        <service id="Leogout\Bundle\SeoBundle\Seo\Basic\BasicSeoGenerator" alias="leogout_seo.generator.basic" />
     </services>
 </container>

--- a/Resources/config/seo/og.xml
+++ b/Resources/config/seo/og.xml
@@ -14,5 +14,8 @@
             <configurator service="leogout_seo.configurator.og" method="configure" />
             <tag name="leogout_seo.generator" alias="og"/>
         </service>
+
+        <!-- for autowiring -->
+        <service id="Leogout\Bundle\SeoBundle\Seo\Og\OgSeoGenerator" alias="leogout_seo.generator.og" />
     </services>
 </container>

--- a/Resources/config/seo/twitter.xml
+++ b/Resources/config/seo/twitter.xml
@@ -14,5 +14,8 @@
             <configurator service="leogout_seo.configurator.twitter" method="configure" />
             <tag name="leogout_seo.generator" alias="twitter"/>
         </service>
+
+        <!-- for autowiring -->
+        <service id="Leogout\Bundle\SeoBundle\Seo\Twitter\TwitterSeoGenerator" alias="leogout_seo.generator.twitter" />
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,5 +15,8 @@
             <argument id="leogout_seo.provider.generator" type="service"/>
             <tag name="twig.extension"/>
         </service>
+
+        <!-- for autowiring -->
+        <service id="Leogout\Bundle\SeoBundle\Provider\SeoGeneratorProvider" alias="leogout_seo.provider.generator" />
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,9 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="leogout_seo.provider.generator" class="Leogout\Bundle\SeoBundle\Provider\SeoGeneratorProvider" public="true">
-            <argument type="collection"/>
-        </service>
+        <service id="leogout_seo.provider.generator" class="Leogout\Bundle\SeoBundle\Provider\SeoGeneratorProvider" public="true" />
+
         <service id="leogout_seo.tag_factory" class="Leogout\Bundle\SeoBundle\Factory\TagFactory"/>
         <service id="leogout_seo.builder" class="Leogout\Bundle\SeoBundle\Builder\TagBuilder" shared="false">
             <argument id="leogout_seo.tag_factory" type="service"/>


### PR DESCRIPTION

Autowiring to providers is not possible on actual version because SeoGeneratorProvider is not taking references of Providers.

This change is making possible to change state of providers using Autowiring functionality.

Example:

service.yaml
```yaml
services:
    Leogout\Bundle\SeoBundle\Seo\Basic\BasicSeoGenerator: '@leogout_seo.generator.basic'
```

IndexController.php
```php
namespace App\Controller\Website;

use Leogout\Bundle\SeoBundle\Seo\Basic\BasicSeoGenerator;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\Routing\Annotation\Route;

class IndexController extends AbstractController
{
    /**
     * @Route("/", name="index")
     */
    public function indexAction(BasicSeoGenerator $basicSeoGenerator)
    {
        $basicSeoGenerator->setTitle('Homepage');

        return $this->render('website/index/index.html.twig');
    }
}
```